### PR TITLE
Fix hotspot create authorization flow and cleanup

### DIFF
--- a/src/Actions.py
+++ b/src/Actions.py
@@ -9,7 +9,7 @@ from logging_config import get_logger
 logger = get_logger()
 
 
-def run_forwarding_fix():
+def run_forwarding_fix() -> bool:
     """
     Enable IP forwarding and add iptables FORWARD rule.
     - sysctl net.ipv4.ip_forward=1  (kernel forwarding)
@@ -41,7 +41,7 @@ def run_forwarding_fix():
         return False
 
 
-def disconnect_station(interface, mac):
+def disconnect_station(interface, mac) -> bool:
     iw_paths = ["/usr/sbin/iw", "/sbin/iw"]
     iw_cmd = None
     for path in iw_paths:

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -149,10 +149,11 @@ class MainWindow:
         # Set version if it cannot be retrieved from __version__ file,
         # then use MainWindow.glade file
         try:
-            version = open(
+            version_path = (
                 os.path.dirname(os.path.abspath(__file__)) + "/__version__"
-                ).readline()
-            self.hotspot_dialog.set_version(version)
+            )
+            with open(version_path, encoding="utf-8") as vf:
+                self.hotspot_dialog.set_version(vf.readline().strip())
         except:
             pass
 
@@ -305,7 +306,7 @@ class MainWindow:
             self.item_show_app.set_label(_("Hide App"))
 
 
-    def on_window_delete_event(self, widget=None, event=None):
+    def on_window_delete_event(self, widget=None, event=None) -> bool:
         self.window.hide()
         self.item_show_app.set_label(_("Show App"))
         return True
@@ -330,7 +331,7 @@ class MainWindow:
         self.hotspot_settings.autostart = state
         self.hotspot_settings.set_autostart(state)
 
-    def on_forwarding_switch_state_set(self, switch, state):
+    def on_forwarding_switch_state_set(self, switch, state) -> bool:
         self.hotspot_settings.forwarding = state
         self.hotspot_settings.write_config()
         return False
@@ -442,7 +443,7 @@ class MainWindow:
                 self.indicator.set_icon("pardus-hotspot-status-off-symbolic")
 
 
-    def check_wifi_and_update_hotspot(self):
+    def check_wifi_and_update_hotspot(self) -> bool:
         """
         Regularly checks Wi-Fi status and updates the hotspot state and UI
         elements accordingly.
@@ -595,7 +596,7 @@ class MainWindow:
 
         self.devices_listbox.show_all()
 
-    def _create_device_row(self, device):
+    def _create_device_row(self, device) -> Gtk.ListBoxRow:
         """Create a single device row widget."""
         row = Gtk.ListBoxRow()
         box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
@@ -705,7 +706,7 @@ class MainWindow:
                 error_dialog.destroy()
             self.update_connected_devices()
 
-    def get_signal_icon(self, signal):
+    def get_signal_icon(self, signal) -> str:
         """Get WiFi icon based on signal strength."""
         if signal >= -50:
             return "network-wireless-signal-excellent-symbolic"
@@ -718,7 +719,7 @@ class MainWindow:
         else:
             return "network-wireless-signal-none-symbolic"
 
-    def format_time(self, seconds):
+    def format_time(self, seconds) -> str:
         if seconds < 60:
             return f"{seconds}s"
         elif seconds < 3600:
@@ -881,7 +882,7 @@ class MainWindow:
         self.grant_netdev_button.set_visible(False)
 
 
-    def on_grant_netdev_button_clicked(self, button):
+    def on_grant_netdev_button_clicked(self, button) -> bool:
         """
         Run pkexec to add the current user to the netdev group
         """
@@ -921,7 +922,7 @@ class MainWindow:
             )
 
 
-    def on_group_add_stderr(self, source, condition):
+    def on_group_add_stderr(self, source, condition) -> bool:
         if condition == GLib.IO_HUP:
             return False
         line = source.readline()

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -6,11 +6,14 @@ import grp
 import os
 import qrcode
 import io
+from logging_config import get_logger
+logger = get_logger()
 
 import hotspot
 from network_utils import get_interface_names
 from hotspot_settings import HotspotSettings
 from connected_devices import ConnectedDevices
+
 
 try:
     gi.require_version('AppIndicator3', '0.1')
@@ -837,15 +840,24 @@ class MainWindow:
                 self.menu_button.set_visible(False)
                 return
 
-            # After successful connection setup, change the button to red
-            style_context.add_class(Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION)
-            style_context.remove_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
-
             # Check if forwarding is enabled
             forwarding_enabled = self.forwarding_switch.get_active()
 
             hotspot.set_network_interface(ifname)
-            hotspot.create_hotspot(ssid, password, selected_encrypt, selected_band, forwarding_enabled)
+            try:
+                success = hotspot.create_hotspot(ssid, password, selected_encrypt, selected_band, forwarding_enabled)
+                if not success:
+                    logger.info("Hotspot creation cancelled/authorization failed")
+                    return
+
+            except Exception as e:
+                logger.error(f"Hotspot creation failed unexpectedly: {e}")
+                self.hotspot_stack.set_visible_child_name("page_errors")
+                self.warning_msgs_lbl.set_text(
+                    _("An unexpected error occurred while creating hotspot.")
+                )
+                return
+
             self.device_tracker.set_interface(ifname)
             self.devices_expander.set_visible(True)
 
@@ -863,6 +875,9 @@ class MainWindow:
             self.hotspot_settings.encryption = encrypt
             self.hotspot_settings.write_config()
 
+            # Apply connected-state button style only after successful creation.
+            style_context.add_class(Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION)
+            style_context.remove_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
             self.create_button.set_label(_("Disable Connection"))
             self.item_enable.set_label(_("Disable"))
             self.qr_image.set_visible(True)

--- a/src/connected_devices.py
+++ b/src/connected_devices.py
@@ -42,7 +42,7 @@ class ConnectedDevices:
             for mac, info in stations.items()
         ]
 
-    def _get_stations(self) -> dict:
+    def _get_stations(self) -> dict | None:
         iw_cmd = self._find_iw()
         if not iw_cmd:
             return {}
@@ -61,7 +61,7 @@ class ConnectedDevices:
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             return {}
 
-    def _find_iw(self) -> str:
+    def _find_iw(self) -> str | None:
         for path in self.IW_PATHS:
             if path == "iw" or os.path.exists(path):
                 return path

--- a/src/connected_devices.py
+++ b/src/connected_devices.py
@@ -19,7 +19,7 @@ class ConnectedDevices:
     def set_interface(self, interface):
         self._interface = interface
 
-    def get_devices(self):
+    def get_devices(self) -> list[dict]:
         """
         Returns list of dicts with keys: 'mac', 'ip', 'signal'
         """
@@ -42,7 +42,7 @@ class ConnectedDevices:
             for mac, info in stations.items()
         ]
 
-    def _get_stations(self):
+    def _get_stations(self) -> dict:
         iw_cmd = self._find_iw()
         if not iw_cmd:
             return {}
@@ -61,13 +61,13 @@ class ConnectedDevices:
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             return {}
 
-    def _find_iw(self):
+    def _find_iw(self) -> str:
         for path in self.IW_PATHS:
             if path == "iw" or os.path.exists(path):
                 return path
         return None
 
-    def _parse_stations(self, output):
+    def _parse_stations(self, output) -> dict:
         """
         Parse iw station dump output
         """
@@ -85,7 +85,7 @@ class ConnectedDevices:
             }
         return stations
 
-    def _get_arp_table(self):
+    def _get_arp_table(self) -> dict:
         """
         Read ARP table from /proc/net/arp for our interface
         """

--- a/src/hotspot.py
+++ b/src/hotspot.py
@@ -341,7 +341,7 @@ def ap_channel_for_band(band: str) -> int:
     return 1 if band == "bg" else 36
 
 
-def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward=False):
+def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward=False) -> bool:
     """
     Create a Wi-Fi hotspot with parameters.
 
@@ -355,7 +355,6 @@ def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward
     global current_hotspot_uuid, forwarding_configured
     global active_connection_path, active_connection_proxy, active_connection_props
 
-    disconnect_wifi_connections()
 
     # Default to SAE (WPA3) if password exists, otherwise no encryption
     if passwd:
@@ -410,22 +409,7 @@ def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward
         "ipv6": ip6_settings,
     })
 
-    # Remove any existing hotspot before creating new one
-    remove_hotspot()
-
     try:
-        bus = _get_bus()
-        settings_iface = _get_settings_iface()
-        nm_iface = _get_nm_iface()
-
-        # Create new connection
-        connection_path = settings_iface.AddConnection(connection)
-
-        # Activate the connection
-        active_connection_path = nm_iface.ActivateConnection(
-            connection_path, device_path, "/"
-        )
-
         # For docker - ip forwarding control
         # Use forwarding_configured flag to prevent repeated pkexec dialogs
         # after sleep/wake, screen lock, or SAE-> WPA-PSK fallback
@@ -437,10 +421,27 @@ def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward
                 forwarding_configured = (res.returncode == 0)
                 if not forwarding_configured:
                     logger.warning("User cancelled or forwarding config failed (pkexec rc=%d)", res.returncode)
+                    return False
             except Exception as e:
                 forwarding_configured = False
                 logger.warning("Failed to configure IP forwarding")
                 logger.debug(f"Process error details: {e}")
+                return False
+
+        disconnect_wifi_connections() # only if authentication success
+        remove_hotspot()
+
+        bus = _get_bus()
+        settings_iface = _get_settings_iface()
+        nm_iface = _get_nm_iface()
+
+        # Create new connection
+        connection_path = settings_iface.AddConnection(connection)
+
+        # Activate the connection
+        active_connection_path = nm_iface.ActivateConnection(
+            connection_path, device_path, "/"
+        )
 
         active_connection_proxy = bus.get_object(
             "org.freedesktop.NetworkManager", active_connection_path
@@ -467,6 +468,7 @@ def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward
         logger.error("Failed to create hotspot")
         logger.debug(f"Error details: {e}")
         raise
+    return True
 
 
 def update_hotspot_settings(band, encrypt, ssid="Hotspot", passwd=None):

--- a/src/hotspot.py
+++ b/src/hotspot.py
@@ -204,40 +204,45 @@ def get_hotspot_connection():
             settings = connection_iface.GetSettings()
 
             if settings["connection"]["type"] == "802-11-wireless" and settings["802-11-wireless"]["mode"] == "ap":
-                return active_conn_path, connection_path, connection_iface, settings
+                return {
+                    "active_conn_path": active_conn_path,
+                    "connection_path": connection_path,
+                    "connection_iface": connection_iface,
+                    "settings": settings
+                }
 
-        return None, None, None, None
+        return None
     except dbus.exceptions.DBusException as e:
         if _is_recoverable_error(e):
             logger.info("DBus connection lost, will reconnect on next call")
             _reset_connection()
         logger.error("Failed to get active hotspot information")
         logger.debug(f"Error details: {e}")
-        return None, None, None, None
+        return None
     except Exception as e:
         logger.error("Failed to get active hotspot information")
         logger.debug(f"Error details: {e}")
-        return None, None, None, None
+        return None
 
 
-def get_active_hotspot_info():
+def get_active_hotspot_info() -> dict | None:
     """Return SSID, password, and encryption type of the active hotspot"""
-    _, _, connection_iface, settings = get_hotspot_connection()
-
-    if not settings:
+    hotspot_info = get_hotspot_connection()
+    
+    if not hotspot_info:
         return None
 
     try:
-        ssid_bytes = settings["802-11-wireless"]["ssid"]
+        ssid_bytes = hotspot_info["settings"]["802-11-wireless"]["ssid"]    
         ssid = "".join([chr(b) for b in ssid_bytes])
         password = ""
         encryption = ""
 
-        if "802-11-wireless-security" in settings:
-            wireless_security = settings.get("802-11-wireless-security", {})
+        if "802-11-wireless-security" in hotspot_info["settings"]:
+            wireless_security = hotspot_info["settings"].get("802-11-wireless-security", {})
 
             try:
-                secrets = connection_iface.GetSecrets("802-11-wireless-security")
+                secrets = hotspot_info["connection_iface"].GetSecrets("802-11-wireless-security")
                 if "802-11-wireless-security" in secrets:
                     wireless_security.update(secrets["802-11-wireless-security"])
             except dbus.exceptions.DBusException as e:
@@ -266,12 +271,17 @@ def get_active_hotspot_info():
         return None
 
 
-def disable_connection():
+def disable_connection() -> bool:
     """
     Disable active hotspot connection if exists.
     Returns True if successfully disabled.
     """
-    active_conn_path, _, _, _ = get_hotspot_connection()
+    
+    hotspot_info = get_hotspot_connection()
+    if not hotspot_info:
+        return False
+
+    active_conn_path = hotspot_info["active_conn_path"]
     if active_conn_path:
         try:
             nm_iface = _get_nm_iface()
@@ -310,7 +320,7 @@ def set_network_interface(iface):
         raise
 
 
-def check_ip_forwarding():
+def check_ip_forwarding() -> bool:
     """
     Check if system needs IP forwarding fix.
     """
@@ -324,6 +334,11 @@ def check_ip_forwarding():
         return docker_exists or forwarding_disabled
     except (OSError, IOError):
         return True
+
+
+def ap_channel_for_band(band: str) -> int:
+    """Return NM 802.11 AP channel: 2.4 GHz (bg) -> 1, 5 GHz (a) -> 36."""
+    return 1 if band == "bg" else 36
 
 
 def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward=False):
@@ -352,9 +367,7 @@ def create_hotspot(ssid="Hotspot", passwd=None, encrypt=None, band=None, forward
     # Default to 2.4GHz band if not specified or invalid
     band = band if band in ["bg", "a"] else "bg"
 
-    # For 2.4GHz (bg), use channel 1
-    # For 5GHz (a), use channel 36
-    channel = dbus.UInt32(1 if band == "bg" else 36)
+    channel = dbus.UInt32(ap_channel_for_band(band))
 
     current_hotspot_uuid = str(uuid.uuid4())
 
@@ -492,7 +505,7 @@ def update_hotspot_settings(band, encrypt, ssid="Hotspot", passwd=None):
         "ssid": ssid_bytes,
         "mode": "ap",
         "band": wifi_band,
-        "channel": dbus.UInt32(1),
+        "channel": dbus.UInt32(ap_channel_for_band(wifi_band)),
     }
 
     # Security settings
@@ -506,7 +519,7 @@ def update_hotspot_settings(band, encrypt, ssid="Hotspot", passwd=None):
         security_settings["psk"] = passwd_bytes
 
 
-def remove_hotspot():
+def remove_hotspot() -> bool:
     """Clean up and remove the active hotspot connection."""
     global device_path, device_proxy, device_iface
     global active_connection_path, active_connection_proxy, active_connection_props
@@ -598,12 +611,12 @@ def get_connection_state():
         return 0
 
 
-def is_connection_activated():
+def is_connection_activated() -> bool:
     """Check if hotspot is successfully activated."""
     return get_connection_state() == 2  # NM_ACTIVE_CONNECTION_STATE_ACTIVATED
 
 
-def is_wifi_enabled():
+def is_wifi_enabled() -> bool:
     """Check if WiFi hardware is enabled and available."""
     try:
         nm_props = _get_nm_props()
@@ -617,7 +630,7 @@ def is_wifi_enabled():
         return False
 
 
-def disconnect_station(interface, mac):
+def disconnect_station(interface, mac) -> bool:
     if not interface or not mac:
         return False
 

--- a/src/hotspot_settings.py
+++ b/src/hotspot_settings.py
@@ -98,7 +98,7 @@ class HotspotSettings:
             self.create_default_config(force=True)
 
 
-    def write_config(self):
+    def write_config(self) -> bool:
         self.config['Hotspot'] = self._prepare_config_dict()
 
         if self.create_dir(self.config_dir):

--- a/src/hotspot_settings.py
+++ b/src/hotspot_settings.py
@@ -110,7 +110,7 @@ class HotspotSettings:
         return False
 
 
-    def create_dir(self, dir_path):
+    def create_dir(self, dir_path) -> bool:
         try:
             Path(dir_path).mkdir(parents=True, exist_ok=True)
             return True

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -11,7 +11,7 @@ import logging.handlers
 from pathlib import Path
 
 
-def setup_logging():
+def setup_logging() -> logging.Logger:
 
     # Create log directory
     log_dir = Path.home() / ".cache" / "pardus" / "pardus-hotspot"
@@ -62,7 +62,7 @@ def setup_logging():
     return logger
 
 
-def get_logger():
+def get_logger() -> logging.Logger:
 
     return logging.getLogger('pardus-hotspot')
 


### PR DESCRIPTION
## Summary
- The hotspot create flow could proceed without properly waiting for authorization result, causing premature creation-side effects and UI inconsistency.
- Improve hotspot-related type hints and readability in helper/UI modules.
- Simplify hotspot connection payload/channel selection and align helper behavior.
- Apply connected-state UI only after successful authorization and hotspot activation.
## Test plan
- Start hotspot with forwarding enabled and verify creation proceeds only after successful authorization.
- Cancel/deny authorization and verify hotspot is not activated and UI stays in create state.
- Disable hotspot and verify teardown and create-state UI restoration.